### PR TITLE
session stealing prevention and bubblewrap

### DIFF
--- a/auth_service.pl
+++ b/auth_service.pl
@@ -151,6 +151,36 @@ if ( my $row = $sth->fetchrow_hashref ) {
 
     }
 
+    sub find_other_user_with_port {
+        my ( $username , $port ) = @_;
+
+        print LOG "Checking other users having port $port (not $username)\n";
+
+        # ensure not stealing other users session
+        my $sql = 'select username from users where username != ? and port = ?';
+
+        my $sth = $dbh->prepare( $sql )
+            || print LOG $dbh->errstr;
+
+        #print LOG $sth->{Statement} . "\n";
+
+        $sth->execute($username, $port )
+            || print LOG $sth->errstr . "\n";
+
+        my $row = $sth->fetchrow_hashref;
+
+        $sth->finish();
+
+        if ( $row ) {
+            my $other_user = $row->{username};
+            print LOG "Found user $other_user having same port $port as $username\n";
+            return $other_user;
+        }
+
+        print LOG "No other users having port $port\n";
+        return undef;
+    }
+
     sub handle_request {
         
         my $self = shift;
@@ -226,8 +256,17 @@ END_SQL
 
                 # reconnect to last saved db session
                 if ($row->{auth_key} and $row->{port}) {
-                    $auth_key = $row->{auth_key};
-                    $port = $row->{port};
+                    # ensure not stealing portsd from other users
+                    my $other_user = find_other_user_with_port(
+                        $name_provided, $row->{port});
+                    
+                    if ( $other_user ) {
+                        print LOG "Redirect to user_app_service\n";
+                    } else {
+                        print LOG "Reconnect to last saved session\n";
+                        $auth_key = $row->{auth_key};
+                        $port = $row->{port};
+                    }
                 }
 
                 print LOG "Checkpoint 4\n";

--- a/gdk_broadway_socket.patch
+++ b/gdk_broadway_socket.patch
@@ -1,0 +1,26 @@
+diff --git a/gdk/broadway/broadwayd.c b/gdk/broadway/broadwayd.c
+index 99633ee..ea081e3 100644
+--- a/gdk/broadway/broadwayd.c
++++ b/gdk/broadway/broadwayd.c
+@@ -513,7 +513,7 @@ main (int argc, char *argv[])
+ 
+       port = strtol (display + strlen (":"), NULL, 10);
+       basename = g_strdup_printf ("broadway%d.socket", port + 1);
+-      path = g_build_filename (g_get_user_runtime_dir (), basename, NULL);
++      path = g_build_filename ("/broadwayd", basename, NULL);
+       g_free (basename);
+ 
+       g_print ("Listening on %s\n", path);
+diff --git a/gdk/broadway/gdkbroadway-server.c b/gdk/broadway/gdkbroadway-server.c
+index 8d33293..5ebb0e6 100644
+--- a/gdk/broadway/gdkbroadway-server.c
++++ b/gdk/broadway/gdkbroadway-server.c
+@@ -130,7 +130,7 @@ _gdk_broadway_server_new (const char *display, GError **error)
+ 
+       port = strtol (display + strlen (":"), NULL, 10);
+       basename = g_strdup_printf ("broadway%d.socket", port + 1);
+-      path = g_build_filename (g_get_user_runtime_dir (), basename, NULL);
++      path = g_build_filename ("/broadwayd", basename, NULL);
+       g_free (basename);
+ 
+       address = g_unix_socket_address_new_with_type (path, -1,

--- a/scripts/README
+++ b/scripts/README
@@ -1,0 +1,17 @@
+This directory contains a sample script
+for running Gtk application in a bwrap sandbox,
+setting up a virtual user environment with restricted
+access to a small set of predefined directories.
+
+In order for this to work, the connection between broadwayd
+and the Gtk application must be must be switched to use tcp sockets 
+instead of the default unix domain sockets. With Gtk3, this can be done
+by using a BROADWAY_DISPLAY setting of the form :tcp<N>, whereas <N>
+is the display number. It will result in using tcp port 9090 + <N>
+for communication between the Gtk app and broadwayd. 
+
+We couldn't figure out yet, 
+how to make unix domain sockets work with bwrap.
+
+@see sessionmanager.patch for details
+

--- a/scripts/README
+++ b/scripts/README
@@ -10,8 +10,20 @@ by using a BROADWAY_DISPLAY setting of the form :tcp<N>, whereas <N>
 is the display number. It will result in using tcp port 9090 + <N>
 for communication between the Gtk app and broadwayd. 
 
-We couldn't figure out yet, 
-how to make unix domain sockets work with bwrap.
-
 @see sessionmanager.patch for details
+
+Explanation
+
+Broadwayd uses **abstract** unix domain sockets for communication 
+between broadwayd and Gtk application. The name of the abstract
+socket is created with the aid of g_get_user_runtime_dir(). 
+This way, it will create different socket names for broadwayd (runing 
+under an ordinary user account) and the Gtk application (running under 
+a virtual bwrap user).
+
+For abstract unix domain sockets to work with different user contexts,
+Gdk broadway must be patched to use a fixed abstract socket name, not
+depending on the user.
+
+@see gdk_broadway_socket.patch for details
 

--- a/scripts/bwrap_opg5
+++ b/scripts/bwrap_opg5
@@ -1,0 +1,240 @@
+#!/bin/sh
+#*****************************************************************
+#*
+#*   OPAG - Opag Informatik AG
+#*
+#*   bwrap_opg5 - bwrap script for OPG5
+#*
+#*   Created :   16.02.23 A. Kurz
+#*
+#*****************************************************************
+
+# Setttings
+
+# the base directory for virtual home, tmp, log
+# can be overridden via env BROADWAY_BASEDIR
+BROADWAY_BASEDIR="${BROADWAY_BASEDIR:-/home/broadwayd}"
+
+# environment within bwrap
+G_MESSAGES_DEBUG=
+XDG_DATA_DIRS=/usr/share
+OPG_INSTALL_DIR=/opt/casy/gtk3/.Linux.4.x86_64
+PATH=${OPG_INSTALL_DIR}/bin:/opt/casy/bin:/usr/bin:/bin:.
+LANG=de_CH.utf-8
+
+# Setup logging
+LOG_PREFIX="broadway $0:"
+LOG_PATH="${BROADWAY_BASEDIR}/log"
+LOG_FILE="${LOG_PATH}/${BROADWAY_USER:-unknown}.log"
+
+# postfix for username, running in developer mode
+DEVEL_POSTFIX="_devel"
+
+fatal() {
+  msg="${LOG_PREFIX} Fatal: $*"
+  echo "$msg"
+  echo "$msg" | logger -p local3.info
+  exit 1
+}
+
+if [ -n "${LOG_PATH}" -a ! -d "${LOG_PATH}" ]; then
+  mkdir -p "${LOG_PATH}" || \
+  fatal "${LOG_PATH}: cannot create directory"
+fi
+
+# comment out to preserve logfile
+[ -n "${LOG_FILE}" ] && rm -f ${LOG_FILE}
+
+die() {
+  echo "${LOG_PREFIX} Abort: $1" | tee -a "${LOG_FILE}"
+  exit 1
+}
+
+log() {
+  echo "${LOG_PREFIX} $*" | tee -a "${LOG_FILE}"
+}
+
+# Parse script arguments
+OPTS="htvl:p:"
+
+usage() {
+  echo "Usage: start_opg [-${OPTS}] CONF_KEY [ApplBaseDir]" | tee -a "${LOG_FILE}"
+  echo "  -h            show usage" | tee -a "${LOG_FILE}"
+  echo "  -t            run in terminal, experimental" | tee -a "${LOG_FILE}"
+  echo "  -v            enable debug output" | tee -a "${LOG_FILE}"
+  echo "  -p Profile    enable developer mode [AppDevel|SysDevel]" | tee -a "${LOG_FILE}"
+  echo "  -l locale     set LANG (default ${LANG})" | tee -a "${LOG_FILE}"
+  echo ""
+  echo "Environment:"
+  echo "  GDK_BACKEND        required, (${GDK_BACKEND})"
+  echo "  BROADWAY_DISPLAY   required, (${BROADWAY_DISPLAY})"
+  echo "  BROADWAY_USER      required, virtual username (${BROADWAY_USER})"
+  echo "  BROADWAY_BASEDIR   optional, base for virtual users (${BROADWAY_BASEDIR})"
+  exit 1
+}
+
+while getopts $opts ":${OPTS}" c
+do
+    case $c in
+    h) usage;;
+    t) RUN_IN_TERMINAL=Yes;;
+    v) G_MESSAGES_DEBUG=all;;
+    l) LANG=${OPTARG};;
+    p) APPL_PROFILE="-p ${OPTARG}";;
+    \?) log "illegal option -- ${OPTARG}"
+    usage;;
+    esac
+done
+shift `expr $OPTIND - 1`
+
+# script arguments
+CONF_KEY="$1"
+
+# default application settings
+APPL_BASE_DIR="${2:-/home/kommerz}"
+APPL_INI_FILE="${APPL_BASE_DIR}/local/opg"
+
+#
+## variables
+#
+BROADWAY_USERS_HOME="${BROADWAY_BASEDIR}/home"
+BROADWAY_USER_DIR="${BROADWAY_USERS_HOME}/${BROADWAY_USER}"
+BWRAP_USER_HOME="/home/${BROADWAY_USER}"
+
+BWRAP_MOUNTS="
+    --ro-bind-try /home/kommerz /home/kommerz"
+
+if [ -n "${APPL_PROFILE}" ]; then
+  log "developer mode enabled"
+  BROADWAY_USER_DIR="${BROADWAY_USERS_HOME}/${BROADWAY_USER}${DEVEL_POSTFIX}"
+  BWRAP_USER_HOME="/home/${BROADWAY_USER}${DEVEL_POSTFIX}"
+
+  if [ "${APPL_BASE_DIR}" != "/home/kommerz" ]; then
+    BWRAP_MOUNTS="${BWRAP_MOUNTS} --ro-bind-try ${APPL_BASE_DIR} ${APPL_BASE_DIR}"
+  fi
+fi
+
+# add additional mounts for required symbolic links
+for subdir in \
+  local \
+  r1/Dist \
+  r1/Source \
+  r1/Kommerz
+do
+  if [ -L "${APPL_BASE_DIR}/${subdir}" ]; then
+    LINK_TARGET=`readlink ${APPL_BASE_DIR}/${subdir}`
+    BWRAP_MOUNTS="${BWRAP_MOUNTS}
+    --ro-bind-try ${APPL_BASE_DIR}/${subdir} ${LINK_TARGET}"
+  fi
+done
+
+#
+## generate random userid over 400000
+#
+USER_ID=$((40000 + RANDOM % 10000))
+
+
+OPG_EXE="${OPG_INSTALL_DIR}/bin/opg"
+OPG_CMD="${OPG_EXE} ${APPL_PROFILE} ${APPL_INI_FILE} ${CONF_KEY} ${APPL_BASE_DIR}"
+
+if [ "${RUN_IN_TERMINAL}" = "Yes" ]; then
+  # Terminal has autorisation problems
+  #  Authentication Rejected, reason : None of the authentication protocols
+  #  specified are supported and host-based authentication failed
+  OPG_CMD="/usr/bin/xfce4-terminal -x /bin/bash -c \"${OPG_CMD}\""
+fi
+
+# debugging commands
+#OPG_CMD="ls -la /home/${BROADWAY_USER}"
+#OPG_CMD="xterm"
+
+#
+## startup log
+#
+echo "Starting bwrap session" >> ${LOG_FILE}
+echo "CONF_KEY=${CONF_KEY}" >> ${LOG_FILE}
+echo "APPL_BASE_DIR=${APPL_BASE_DIR}" >> ${LOG_FILE}
+echo "APPL_INI_FILE=${APPL_INI_FILE}" >> ${LOG_FILE}
+echo "APPL_PROFILE=${APPL_PROFILE}" >> ${LOG_FILE}
+echo "BROADWAY_USERS_HOME=${BROADWAY_USERS_HOME}" >> ${LOG_FILE}
+echo "BROADWAY_USER_DIR=${BROADWAY_USER_DIR}" >> ${LOG_FILE}
+echo "BWRAP_MOUNTS=${BWRAP_MOUNTS}" >> ${LOG_FILE}
+echo "" >> ${LOG_FILE}
+echo "Application Environment" >> ${LOG_FILE}
+echo "G_MESSAGES_DEBUG=${G_MESSAGES_DEBUG}" >> ${LOG_FILE}
+echo "XDG_DATA_DIRS=${XDG_DATA_DIRS}" >> ${LOG_FILE}
+echo "OPG_INSTALL_DIR=${OPG_INSTALL_DIR}" >> ${LOG_FILE}
+echo "PATH=${PATH}" >> ${LOG_FILE}
+echo "LANG=${LANG}" >> ${LOG_FILE}
+echo "" >> ${LOG_FILE}
+echo "OPG_CMD=${OPG_CMD}" >> ${LOG_FILE}
+echo "" >> ${LOG_FILE}
+
+#
+## run some checks
+#
+
+if [ ! -n "${CONF_KEY}" ]; then
+  log "Missing CONF_KEY"
+  usage
+fi
+
+if [ ! -n "${BROADWAY_USER}" ]; then
+  die "BROADWAY_USER missing in envronment"
+fi
+
+if [ ! -n "${GDK_BACKEND}" ]; then
+  die "GDK_BACKEND missing in envronment"
+fi
+
+if [ ! -n "${BROADWAY_DISPLAY}" ]; then
+  die "BROADWAY_DISPLAY missing in envronment"
+fi
+
+if [ ! -d "${BROADWAY_BASEDIR}" ]; then
+  die "${BROADWAY_BASEDIR}: directory doesn't exist (BROADWAY_BASEDIR)"
+fi
+
+if [ ! -d "${BROADWAY_USER_DIR}" ]; then
+  echo "Creating BROADWAY_USER_DIR ${BROADWAY_USER_DIR}" >> ${LOG_FILE}
+  mkdir -p "${BROADWAY_USER_DIR}" || \
+  die "${BROADWAY_USER_DIR}: cannot create directory"
+fi
+
+#
+## run bubblewrap
+#
+exec /usr/bin/bwrap --unshare-user \
+  --dir /tmp \
+  --dir /var \
+  --uid "${USER_ID}" \
+  --gid "${USER_ID}" \
+  --symlink /usr/lib /lib \
+  --symlink /usr/lib64 /lib64 \
+  --symlink /usr/bin /bin \
+  --symlink /usr/bin /sbin \
+  --ro-bind /usr/lib /usr/lib \
+  --ro-bind /usr/lib64 /usr/lib64 \
+  --ro-bind /usr/bin /usr/bin \
+  --ro-bind /etc /etc \
+  --ro-bind-try /etc/gtk-2.0 /etc/gtk-2.0 \
+  --ro-bind-try /etc/gtk-3.0 /etc/gtk-3.0 \
+  --ro-bind-try /opt/casy /opt/casy \
+  --ro-bind-try /home/kommerz /home/kommerz \
+  ${BWRAP_MOUNTS} \
+  --ro-bind /usr/share /usr/share \
+  --bind "${BROADWAY_USER_DIR}" "${BWRAP_USER_HOME}" \
+  --proc /proc \
+  --dev-bind /dev /dev \
+  --tmpfs /tmp --tmpfs /run \
+  --setenv HOME "${BWRAP_USER_HOME}" \
+  --chdir "/home/${BROADWAY_USER}" \
+  --setenv USER "${BROADWAY_USER}" \
+  --setenv G_MESSAGES_DEBUG "${G_MESSAGES_DEBUG}" \
+  --setenv XDG_DATA_DIRS "${XDG_DATA_DIRS}" \
+  --setenv PATH "${PATH}" \
+  --setenv LANG "${LANG}" \
+  --new-session \
+  ${OPG_CMD} >>${LOG_FILE} 2>&1
+
+# NOTREACHED

--- a/scripts/bwrap_opg5
+++ b/scripts/bwrap_opg5
@@ -1,11 +1,11 @@
 #!/bin/sh
 #*****************************************************************
 #*
-#*   OPAG - Opag Informatik AG
+#*   casymir schweiz ag
 #*
 #*   bwrap_opg5 - bwrap script for OPG5
 #*
-#*   Created :   16.02.23 A. Kurz
+#*   Created :   16.02.23 A. Kurz, F. Paquet
 #*
 #*****************************************************************
 
@@ -146,7 +146,7 @@ fi
 
 # debugging commands
 #OPG_CMD="ls -la /home/${BROADWAY_USER}"
-#OPG_CMD="xterm"
+#OPG_CMD="/usr/bin/printenv"
 
 #
 ## startup log
@@ -158,6 +158,8 @@ echo "APPL_INI_FILE=${APPL_INI_FILE}" >> ${LOG_FILE}
 echo "APPL_PROFILE=${APPL_PROFILE}" >> ${LOG_FILE}
 echo "BROADWAY_USERS_HOME=${BROADWAY_USERS_HOME}" >> ${LOG_FILE}
 echo "BROADWAY_USER_DIR=${BROADWAY_USER_DIR}" >> ${LOG_FILE}
+echo "GDK_BACKEND=${GDK_BACKEND}" >> ${LOG_FILE}
+echo "BROADWAY_DISPLAY=${BROADWAY_DISPLAY}" >> ${LOG_FILE}
 echo "BWRAP_MOUNTS=${BWRAP_MOUNTS}" >> ${LOG_FILE}
 echo "" >> ${LOG_FILE}
 echo "Application Environment" >> ${LOG_FILE}
@@ -228,13 +230,16 @@ exec /usr/bin/bwrap --unshare-user \
   --dev-bind /dev /dev \
   --tmpfs /tmp --tmpfs /run \
   --setenv HOME "${BWRAP_USER_HOME}" \
-  --chdir "/home/${BROADWAY_USER}" \
+  --chdir "${BWRAP_USER_HOME}" \
   --setenv USER "${BROADWAY_USER}" \
+  --setenv GDK_BACKEND "${GDK_BACKEND}" \
+  --setenv BROADWAY_DISPLAY "${BROADWAY_DISPLAY}" \
   --setenv G_MESSAGES_DEBUG "${G_MESSAGES_DEBUG}" \
   --setenv XDG_DATA_DIRS "${XDG_DATA_DIRS}" \
   --setenv PATH "${PATH}" \
   --setenv LANG "${LANG}" \
+  --setenv LD_LIBRARY_PATH "/opt/casy/gtk3/.Linux.4.x86_64/lib:/usr/lib" \
   --new-session \
-  ${OPG_CMD} >>${LOG_FILE} 2>&1
+  ${OPG_CMD} 2>&1 >>${LOG_FILE}
 
 # NOTREACHED

--- a/scripts/sessionmanager.patch
+++ b/scripts/sessionmanager.patch
@@ -1,0 +1,22 @@
+diff --git a/sessionmanager.pl b/sessionmanager.pl
+index 0efe3c5..60526dd 100644
+--- a/sessionmanager.pl
++++ b/sessionmanager.pl
+@@ -38,7 +38,7 @@ sub fork_it {
+     } elsif ( defined ( $pid ) ) {
+         my $cmd_string = join(' ', @{$args});
+         if ( $display ) {
+-            $cmd_string = "BROADWAY_USER=$username GDK_BACKEND=broadway BROADWAY_DISPLAY=:$display $cmd_string";
++            $cmd_string = "BROADWAY_USER=$username GDK_BACKEND=broadway BROADWAY_DISPLAY=:tcp$display $cmd_string";
+         }
+         print $LOG "Executing: [$cmd_string] username $username\n";
+ 
+@@ -54,7 +54,7 @@ sub fork_it {
+     
+ }
+ 
+-my $args = [ 'broadwayd' , '-p' , $port , ':' . $display ];
++my $args = [ 'broadwayd' , '-p' , $port , ':tcp' . $display ];
+ fork_it( 'broadwayd', $args );
+ 
+ sleep( 2 );

--- a/sessionmanager.pl
+++ b/sessionmanager.pl
@@ -13,11 +13,12 @@ open $LOG , $LOGFILE
 
 use Getopt::Long;
 
-my ( $display , $port , $command );
+my ( $display , $port , $command, $username );
 
 GetOptions(
     'display=i'            => \$display
   , 'port=i'               => \$port
+  , 'username=s'           => \$username
   , 'command=s'            => \$command
 );
 
@@ -37,9 +38,9 @@ sub fork_it {
     } elsif ( defined ( $pid ) ) {
         my $cmd_string = join(' ', @{$args});
         if ( $display ) {
-            $cmd_string = "GDK_BACKEND=broadway BROADWAY_DISPLAY=:$display $cmd_string";
+            $cmd_string = "BROADWAY_USER=$username GDK_BACKEND=broadway BROADWAY_DISPLAY=:$display $cmd_string";
         }
-        print $LOG "Executing: [$cmd_string]\n";
+        print $LOG "Executing: [$cmd_string] username $username\n";
 
         # redirect exec process output to $LOGFILE
         open STDOUT, $LOGFILE or die $!;

--- a/user_app_service.pl
+++ b/user_app_service.pl
@@ -203,7 +203,7 @@ my $session_port_last = fetch_simple_config('session_port_last');
             print LOG "Found auth_key and app selection. Checking user_apps ...\n";
             
             my $sql = <<'END_SQL';
-              select app_command
+              select app_command, users.username
               from users
               inner join  user_apps on users.username = user_apps.username
               inner join  apps on user_apps.app_name = apps.app_name
@@ -273,6 +273,7 @@ END_SQL
                       , "../sessionmanager.pl"
                       , "--display=$display"
                       , "--port=$port"
+                      , "--username=" . $row->{username}
                       , "--command=" . $row->{app_command}
                     );
                     


### PR DESCRIPTION
Hello Dan
Quite a long time ago, since last update.
We've started a project to enhance Gtk Broadway Service in order to make it really useable.

After making some progress with the Gdk Broadway proxy (more about this in a separate e-mail)
we have fixed one cruical bug in the perl authentication and port management service, which allows some
user to "steal" a session from another user. This was possible with dangling cookies hanging around
on one computer, while a second computer connecting to the same session port. Thus we had to add two checks 
to the perl services, ensuring that only one user can use port X. The commit is called "session stealing prevention"

Besides this, we found a way to run all user sessions in a bubblewrap sandbox, creating virtual user sessions. 
In order to achieve this, we had to add BROADWAY_USER=username to the subprocess environment.
We provide our virtual user script in the subfolder ./scripts together with a README file, explaining
some difficulties with the Gdk Broadway communication mechanism, which uses Abstract UNIX domain sockets,
whose naming scheme doesn't allow connections from different linux users. 

Merging this request, doesn't impact any existing running services. 
Our bubblewrap examples are kept separately in the new ./scripts directory, which could be useful for other developers.

regards
fp